### PR TITLE
Fix missing lessons and wrong timetable times

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -62,6 +62,15 @@ function createCalEvent(calendar: ICalCalendar, data: { [x: string]: any; }) {
 
 export function createCalendar(name: string, data: { [x: string]: any; }): ICalCalendar {
   let calendar = ical({ name: name });
+  const tz = "Australia/Adelaide";
+  calendar.timezone(tz);
+  calendar.x([
+    {
+      key: "X-LIC-LOCATION",
+      value: tz
+    }
+  ])
+
   if (data["status"] !== "success") {
     let err = "API response was not successful!";
     console.error(err);


### PR DESCRIPTION
The issue was caused by not explicitly setting the timezone. Everything seems to be working properly now.